### PR TITLE
fix: await route params in admin API handler

### DIFF
--- a/src/app/api/users/admins/me/route.ts
+++ b/src/app/api/users/admins/me/route.ts
@@ -1,7 +1,10 @@
 import { handleGET } from "@/lib/utils/apiHandler";
+import { NextRequest } from "next/server";
 
-export async function GET(req: Request, { params }: any) {
-  return await handleGET(
-    `${process.env.NEXT_PUBLIC_BACKEND_URL}/admin/${params.id}`,
-  );
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return await handleGET(`${process.env.NEXT_PUBLIC_BACKEND_URL}/admin/${id}`);
 }


### PR DESCRIPTION
 await route params in admin API handler
